### PR TITLE
Normalize query string while registering and matching handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ console.log(await result.json());
 //=> { query: 'none' }
 ```
 
+
+Normalize URLs
+------------------------------------------------------------------------------
+
+In some cases, the order of the query params doesn't matter. Then you can set
+`normalizeURLs` to true and the server will normalize (sort) the query params while mocking and matching
+
+```js
+import { QueryParamAwarePretender } from 'pretender-query-param-handler';
+
+let server = new QueryParamAwarePretender({
+  normalizeURLs: true
+});
+
+server.get('/api/graphql?foo=bar&bar=baz', () => [ 200, {}, '{ "query": { "foo": "bar", "bar": "baz" } }'),
+
+let result;
+result = await fetch('/api/graphql?bar=baz&foo=bar');
+console.log(await result.json());
+//=> { query: { foo: 'bar', bar: 'baz' } }
+
+```
+
+
 Contributing
 ------------------------------------------------------------------------------
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -61,6 +61,20 @@ export class QueryParamAwarePretender extends Pretender {
     OPTIONS: new Map(),
   };
 
+  normalizeURLs = false;
+
+  constructor(options) {
+    super(arguments);
+
+    if (
+      typeof options === 'object' &&
+      options !== null &&
+      typeof options.normalizeURLs === 'boolean'
+    ) {
+      this.normalizeURLs = options.normalizeURLs;
+    }
+  }
+
   register(verb, url, qpHandler, async) {
     let { pathname, search } = new URL(url, document.baseURI);
 
@@ -72,6 +86,8 @@ export class QueryParamAwarePretender extends Pretender {
       pathnameHandlersMap.set(pathname, handler);
     }
 
+    // sort query params so that the order doesn't matter
+    search = this.normalizeURLs ? normalizeQueryString(url) : search;
     handler.add(search, qpHandler, async);
 
     return super.register(verb, pathname, handler.handler, async);
@@ -80,6 +96,8 @@ export class QueryParamAwarePretender extends Pretender {
   // instrumented to provide a nicer error message when a handler for a given queryString is not found
   _handlerFor(verb, url, request) {
     let { pathname, search } = new URL(url, document.baseURI);
+
+    search = this.normalizeURLs ? normalizeQueryString(url) : search;
 
     let handlerFound = super._handlerFor(verb, pathname, request);
 


### PR DESCRIPTION
This allows the application to more easily mock requests where it doesn't care about parameter order, which is particularly useful when introducing `pretender-query-param-handler` to an existing codebase.