### PR TITLE
fix: return the correct handler instance for register function

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -88,9 +88,12 @@ export class QueryParamAwarePretender extends Pretender {
 
     // sort query params so that the order doesn't matter
     search = this.normalizeURLs ? normalizeQueryString(url) : search;
-    handler.add(search, qpHandler, async);
 
-    return super.register(verb, pathname, handler.handler, async);
+    // qpHandler's call count is set up in the add function
+    handler.add(search, qpHandler, async);
+    super.register(verb, pathname, handler.handler, async);
+
+    return qpHandler;
   }
 
   // instrumented to provide a nicer error message when a handler for a given queryString is not found


### PR DESCRIPTION
It's impossible for the client to tell if their query param URL was called since the wrong handler instance is returned from the `register` function.

If a client does something like:

```
const handler = this.server.get('/api/graphql?foo=bar', () => [
        200,
        {},
        JSON.stringify({ query: 'bar' }),
      ]);

await fetch('/api/graphql?foo=bar');

// At this point handler.numberOfCalls will be 0 but should be 1
```

A function is returned from the base `pretender` class's register function. We actually do not want to return this as this handler is only used to then used to get the function to match the query params url. We want the qpHandler 