### PR TITLE
Allow passthrough handlers

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -91,7 +91,12 @@ export class QueryParamAwarePretender extends Pretender {
 
     // qpHandler's call count is set up in the add function
     handler.add(search, qpHandler, async);
-    super.register(verb, pathname, handler.handler, async);
+    super.register(
+      verb,
+      pathname,
+      qpHandler === this.passthrough ? qpHandler : handler.handler,
+      async
+    );
 
     return qpHandler;
   }


### PR DESCRIPTION
Still trying to understand parts of the code but this PR allows you to do the following:

```js
const server = new QueryParamAwarePretender();
server.post('/screenshot', server.passthrough);
```

Also need to write some test.