### PR TITLE
Pass query parameters to handlers

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -106,7 +106,10 @@ export class QueryParamAwarePretender extends Pretender {
 
   // instrumented to provide a nicer error message when a handler for a given queryString is not found
   _handlerFor(verb, url, request) {
-    let { pathname, search: originalSearchStr } = new URL(url, document.baseURI);
+    let { pathname, search: originalSearchStr } = new URL(
+      url,
+      document.baseURI
+    );
 
     let search = this.normalizeURLs
       ? normalizeQueryString(url)

--- a/addon/index.js
+++ b/addon/index.js
@@ -106,7 +106,7 @@ export class QueryParamAwarePretender extends Pretender {
 
   // instrumented to provide a nicer error message when a handler for a given queryString is not found
   _handlerFor(verb, url, request) {
-    let { pathname, search } = new URL(url, document.baseURI);
+    let { pathname, search, searchParams } = new URL(url, document.baseURI);
 
     search = this.normalizeURLs ? normalizeQueryString(url) : search;
 
@@ -117,6 +117,12 @@ export class QueryParamAwarePretender extends Pretender {
 
       let { result, message, handler } = matchers.get(search);
 
+      const qps = {};
+
+      for (const [key, value] of searchParams.entries()) {
+        qps[key] = value;
+      }
+
       if (result !== MATCH_FOUND) {
         requestRejectionReasons.set(request, message);
         // no fallback if param values don't match
@@ -124,6 +130,8 @@ export class QueryParamAwarePretender extends Pretender {
           handler = matchers.get('').handler; // fallback
         }
       }
+
+      request.queryParams = qps;
 
       return handler ? { handler: handler } : null;
     }

--- a/tests/unit/pretender-query-param-handler-test.js
+++ b/tests/unit/pretender-query-param-handler-test.js
@@ -574,7 +574,7 @@ module('pretender-query-params-handler', function () {
       this.server.shutdown();
     });
 
-    test('query params are used to find the handler', async function (assert) {
+    test('query params are passed to the handler', async function (assert) {
       assert.expect(1);
 
       this.server.get('/api/graphql?foo=bar', (request) => {

--- a/tests/unit/pretender-query-param-handler-test.js
+++ b/tests/unit/pretender-query-param-handler-test.js
@@ -586,7 +586,7 @@ module('pretender-query-params-handler', function () {
           'query params do exist on the request'
         );
 
-        return [200, {}, JSON.stringify({ query: 'bar' })]
+        return [200, {}, JSON.stringify({ query: 'bar' })];
       });
 
       await fetch('/api/graphql?foo=bar');

--- a/tests/unit/pretender-query-param-handler-test.js
+++ b/tests/unit/pretender-query-param-handler-test.js
@@ -581,16 +581,12 @@ module('pretender-query-params-handler', function () {
         assert.deepEqual(
           request.queryParams,
           {
-            foo : 'bar'
+            foo: 'bar',
           },
-          'query params do exist on the request',
+          'query params do exist on the request'
         );
 
-        return [
-          200,
-          {},
-          JSON.stringify({ query: 'bar' }),
-        ]
+        return [200, {}, JSON.stringify({ query: 'bar' })]
       });
 
       await fetch('/api/graphql?foo=bar');

--- a/tests/unit/pretender-query-param-handler-test.js
+++ b/tests/unit/pretender-query-param-handler-test.js
@@ -575,10 +575,16 @@ module('pretender-query-params-handler', function () {
     });
 
     test('query params are used to find the handler', async function (assert) {
-      assert.expect(1)
+      assert.expect(1);
 
       this.server.get('/api/graphql?foo=bar', (request) => {
-        assert.deepEqual(request.queryParams, { foo : 'bar' }, 'query params do exist on the request');
+        assert.deepEqual(
+          request.queryParams,
+          {
+            foo : 'bar'
+          },
+          'query params do exist on the request',
+        );
 
         return [
           200,

--- a/tests/unit/pretender-query-param-handler-test.js
+++ b/tests/unit/pretender-query-param-handler-test.js
@@ -576,8 +576,8 @@ module('pretender-query-params-handler', function () {
 
     test('query params are used to find the handler', async function (assert) {
       assert.expect(1)
-      const handler = this.server.get('/api/graphql?foo=bar', (request) => {
 
+      this.server.get('/api/graphql?foo=bar', (request) => {
         assert.deepEqual(request.queryParams, { foo : 'bar' }, 'query params do exist on the request');
 
         return [
@@ -585,10 +585,9 @@ module('pretender-query-params-handler', function () {
           {},
           JSON.stringify({ query: 'bar' }),
         ]
-      }
-    );
+      });
 
-    await fetch('/api/graphql?foo=bar');
+      await fetch('/api/graphql?foo=bar');
     });
   });
 });

--- a/tests/unit/pretender-query-param-handler-test.js
+++ b/tests/unit/pretender-query-param-handler-test.js
@@ -588,7 +588,7 @@ module('pretender-query-params-handler', function () {
       }
     );
 
-    let result = await fetch('/api/graphql?foo=bar');
+    await fetch('/api/graphql?foo=bar');
     });
   });
 });

--- a/tests/unit/pretender-query-param-handler-test.js
+++ b/tests/unit/pretender-query-param-handler-test.js
@@ -562,4 +562,33 @@ module('pretender-query-params-handler', function () {
       );
     });
   });
+
+  module('query params for handlerFound', function (hooks) {
+    hooks.beforeEach(function () {
+      this.server = new QueryParamAwarePretender(() => {}, {
+        forcePassthrough: true,
+      });
+    });
+
+    hooks.afterEach(function () {
+      this.server.shutdown();
+    });
+
+    test('query params are used to find the handler', async function (assert) {
+      assert.expect(1)
+      const handler = this.server.get('/api/graphql?foo=bar', (request) => {
+
+        assert.deepEqual(request.queryParams, { foo : 'bar' }, 'query params do exist on the request');
+
+        return [
+          200,
+          {},
+          JSON.stringify({ query: 'bar' }),
+        ]
+      }
+    );
+
+    let result = await fetch('/api/graphql?foo=bar');
+    });
+  });
 });


### PR DESCRIPTION
Within the _handlerFound helper when the request object is received it is missing query params hence this PR fixes this issue by manually adding them back.